### PR TITLE
Update dependencies for 1.20.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+target

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
       <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
     </repository>
     <repository>
-      <id>papermc</id>
-      <url>https://papermc.io/repo/repository/maven-public/</url>
+        <id>papermc</id>
+        <url>https://papermc.io/repo/repository/maven-public/</url>
     </repository>
     <repository>
       <id>dmulloy2-repo</id>
@@ -66,11 +66,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
-      <version>1.16.3-R0.1-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency> 
+        <groupId>org.spigotmc</groupId>
+        <artifactId>spigot-api</artifactId>
+        <version>1.20.4-R0.1-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
     <dependency>
         <groupId>io.papermc</groupId>
         <artifactId>paperlib</artifactId>
@@ -80,7 +80,7 @@
     <dependency>
         <groupId>io.lumine</groupId>
         <artifactId>Mythic-Dist</artifactId>
-        <version>5.2.1</version>  
+        <version>5.6.1</version>  
         <scope>provided</scope>
     </dependency>
       <dependency>
@@ -114,19 +114,19 @@
       <dependency>
           <groupId>io.lumine</groupId>
           <artifactId>MythicLib-dist</artifactId>
-          <version>1.6-SNAPSHOT</version>
+          <version>1.6.2-SNAPSHOT</version>
           <scope>provided</scope>
       </dependency>
   <dependency>
       <groupId>net.Indyuce</groupId>
       <artifactId>MMOItems-API</artifactId>
-      <version>6.9.2-SNAPSHOT</version>
+      <version>6.10-SNAPSHOT</version>
       <scope>provided</scope>
   </dependency>
       <dependency>
           <groupId>com.github.LoneDev6</groupId>
           <artifactId>api-itemsadder</artifactId>
-          <version>3.2.5</version>
+          <version>3.6.1</version>
       </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.apatuka.OraxenUIFilter</groupId>
 	<artifactId>OraxenUIFilter</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 	<name>OraxenUIFilter</name>
 	<description>OraxenUIFilter</description>
 	<build>

--- a/src/main/java/me/apatuka/OraxenUIFilter/OraxenUIFilter.java
+++ b/src/main/java/me/apatuka/OraxenUIFilter/OraxenUIFilter.java
@@ -32,14 +32,14 @@ public class OraxenUIFilter extends JavaPlugin {
 				MMOItems.plugin.getRecipes().reload();
 				MMOItems.plugin.getLanguage().reload();
 				MMOItems.plugin.getDropTables().reload();
-				MMOItems.plugin.getTypes().reload();
+				MMOItems.plugin.getTypes().reload(isEnabled());
 				MMOItems.plugin.getTiers().reload();
 				MMOItems.plugin.getSets().reload();
 				MMOItems.plugin.getUpgrades().reload();
 				MMOItems.plugin.getWorldGen().reload();
 				MMOItems.plugin.getCustomBlocks().reload();
 				MMOItems.plugin.getLayouts().reload();
-				MMOItems.plugin.getFormats().reload();
+				MMOItems.plugin.getLore().reload();
 				MMOItems.plugin.getTemplates().reload();
 				MMOItems.plugin.getLayouts().reload();
 				MMOItems.plugin.getCrafting().reload();
@@ -47,7 +47,7 @@ public class OraxenUIFilter extends JavaPlugin {
 
 			getCommand("uimanager").setExecutor(new Commands());
 		} else {
-			getLogger().log(Level.ERROR, "MythicLib not found, disabling plugin ...");
+			getLogger().log(Level.WARNING, "MythicLib not found, disabling plugin ...");
 			onDisable();
 		}
 


### PR DESCRIPTION
Update dependencies and getTypes().reload function plus replace deprecated getFormats() with getLore().